### PR TITLE
Add helm chart

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+*.yml eol=lf
+*.yaml eol=lf
+*.sh eol=lf
+*.tpl eol=lf
+*.helmignore eol=lf
+*.md eol=lf
+*.txt eol=lf

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a fork from https://github.com/marcinbudny/servicebus_exporter, just for the Helm Chart.
 
+See [the chart readme](https://github.com/giggio/servicebus_exporter/blob/helmchart/charts/servicebusexporter/README.md).
+
 # Azure Service Bus Prometheus exporter
 Azure Service Bus metrics Prometheus exporter. Does not use Azure Monitor, connects to the Service Bus directly and scrapes all queues, topics and subscriptions.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Azure Service Bus Prometheus exporter - Helm Chart
+
+This is a fork from https://github.com/marcinbudny/servicebus_exporter, just for the Helm Chart.
+
 # Azure Service Bus Prometheus exporter
 Azure Service Bus metrics Prometheus exporter. Does not use Azure Monitor, connects to the Service Bus directly and scrapes all queues, topics and subscriptions.
 

--- a/charts/servicebusexporter/.helmignore
+++ b/charts/servicebusexporter/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/servicebusexporter/Chart.yaml
+++ b/charts/servicebusexporter/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "0.1.0"
+description: Azure Service Bus exporter for Prometheus
+name: servicebusexporter
+version: 0.0.1
+home: https://github.com/giggio/servicebus_exporter
+sources:
+- https://github.com/giggio/servicebus_exporter
+maintainers:
+- name: giggio
+  email: giggio@giggio.net

--- a/charts/servicebusexporter/README.md
+++ b/charts/servicebusexporter/README.md
@@ -1,0 +1,102 @@
+# Azure Service Bus Prometheus exporter
+
+Azure Service Bus metrics Prometheus exporter. Does not use Azure Monitor,
+connects to the Service Bus directly and scrapes all queues, topics and
+subscriptions.
+
+## TL;DR;
+
+```console
+$ helm install giggio/servicebusprometheusexporter
+```
+
+## Introduction
+
+This chart bootstraps a [Azure Service Bus Prometheus exporter](https://github.com/marcinbudny/servicebus_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.11+ or Helm 3.0-beta3+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install --name my-release giggio/servicebusprometheusexporter
+```
+
+The command deploys Azure Service Bus Prometheus exporter on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release --purge
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the Azure Service Bus Prometheus exporter chart and their default values.
+
+|            Parameter                      |                                  Description                                  |                           Default                            |
+| ----------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `connectionString` | Connection string for Azure Service Bus. The exporter requires `Manage` SAS policy. | `nil` (required) |
+| `timeout` | Timeout when scraping the Service Bus | `30s` |
+| `verbose` | Enable verbose logging | `false` |
+| `addPromAnnotations` | Adds Prometheus annotations so that scrapping is automatic. | `true` |
+| `rewriteAppHTTPProbers` | Adds `sidecar.istio.io/rewriteAppHTTPProbers` annotation to pods so service health checks work with MTLS when using Istio. | `false` |
+| `imagePullSecrets` | Global Docker registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+| `image.repository` | Image name | `marcinbudny/servicebus_exporter` |
+| `image.tag` | Image tag | `{TAG_NAME}` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods)      |
+| `nameOverride` | String to partially override servicebusprometheusexporter.fullname template with a string (will prepend the release name) | `nil`                               |
+| `fullnameOverride` | String to fully override servicebusprometheusexporter.fullname template with a string | `nil` |
+| `service.type` | Kubernetes Service type | `ClusterIP` |
+| `service.port` | Service HTTP port where the metrics will listen on. | `9580` |
+| `ingress.enabled` | Enable ingress controller resource | `false` |
+| `ingress.annotations` | Ingress annotations | `[]` |
+| `ingress.hosts[0].host` | Hostname to service installation | `nil` |
+| `ingress.hosts[0].paths[0]` | Paths within the url structure | `[]` |
+| `ingress.tls[0].hosts[0]` | TLS hosts | `nil` |
+| `ingress.tls[0].secretName` | TLS Secret (certificates) | `nil` |
+| `virtualservice.enabled` | Enable Istio Virtual Service | `false` |
+| `virtualservice.gateways` | Istio gateways for the Virtual Service | `[]` |
+| `virtualservice.hosts` | Istio hosts for the Virtual Service | `[]` |
+| `virtualservice.matches` | Http matches for the  Virtual Service | `[ { uri: { prefix: '/metrics' } } ]` |
+| `resources` | Resource for the pods (limits, requests etc.) | `{}` |
+| `podSecurityContext` | Pod security context | `{}` |
+| `securityContext` | Security context | `{}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `tolerations` | List of node taints to tolerate | `[]` |
+| `affinity` | Map of node/pod affinities | `{}`                                                         |
+
+The first three parameters and `service.port` map to the command line arguments for the binary.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+  --set 'connectionString=<your connection string>' \
+    giggio/servicebusprometheusexporter
+```
+
+The above command sets the connection string to `<your connection string>`.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml giggio/servicebusprometheusexporter
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml).
+
+> **Tip**: Only set the connection string. You don't need to enable ingress or
+> an Istio Virtual Service. The scrapper will be found because of the annotations.

--- a/charts/servicebusexporter/README.md
+++ b/charts/servicebusexporter/README.md
@@ -7,7 +7,9 @@ subscriptions.
 ## TL;DR;
 
 ```console
-$ helm install giggio/servicebusprometheusexporter
+$ helm repo add sbe https://giggio.github.io/servicebus_exporter/
+$ helm repo update
+$ helm install sbe/servicebusexporter
 ```
 
 ## Introduction
@@ -19,12 +21,21 @@ This chart bootstraps a [Azure Service Bus Prometheus exporter](https://github.c
 - Kubernetes 1.12+
 - Helm 2.11+ or Helm 3.0-beta3+
 
+## Add the repo
+
+Add the help repo:
+
+```console
+$ helm repo add sbe https://giggio.github.io/servicebus_exporter/
+$ helm repo update
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release giggio/servicebusprometheusexporter
+$ helm install --name my-release sbe/servicebusexporter
 ```
 
 The command deploys Azure Service Bus Prometheus exporter on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -85,7 +96,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install --name my-release \
   --set 'connectionString=<your connection string>' \
-    giggio/servicebusprometheusexporter
+    sbe/servicebusexporter
 ```
 
 The above command sets the connection string to `<your connection string>`.
@@ -93,7 +104,7 @@ The above command sets the connection string to `<your connection string>`.
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
 
 ```console
-$ helm install --name my-release -f values.yaml giggio/servicebusprometheusexporter
+$ helm install --name my-release -f values.yaml sbe/serviceexporter
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml).

--- a/charts/servicebusexporter/ci/simple-values.yaml
+++ b/charts/servicebusexporter/ci/simple-values.yaml
@@ -1,0 +1,2 @@
+# fake value so the chart installs
+connectionString: "Endpoint=sb://foobar123456.servicebus.windows.net/;SharedAccessKeyName=foobar123456-role;SharedAccessKey=anNkZmtqbGZsamtzZGZqa2xsa2pmc2FkbGtqZmpzYWxrZmpzYWxmZHNhamZsYXNmYXNmc2Rh"

--- a/charts/servicebusexporter/templates/NOTES.txt
+++ b/charts/servicebusexporter/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Scrape endpoint will be available by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}/metrics
+  {{- end }}
+{{- end }}
+{{- else if and .Values.virtualservice.enabled .Values.virtualservice.hosts }}
+{{- $root := . }}
+{{- range $host := .Values.virtualservice.hosts }}
+  {{- range $match := $root.Values.virtualservice.matches }}
+  http://{{ $host }}:{{ $root.Values.service.port }}{{ $match.uri.prefix }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "servicebusexporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/metrics
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "servicebusexporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "servicebusexporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}/metrics
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "servicebusexporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080/metrics to use your application"
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.service.port }}
+{{- end }}

--- a/charts/servicebusexporter/templates/_helpers.tpl
+++ b/charts/servicebusexporter/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "servicebusexporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "servicebusexporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "servicebusexporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "servicebusexporter.labels" -}}
+app.kubernetes.io/name: {{ include "servicebusexporter.name" . }}
+helm.sh/chart: {{ include "servicebusexporter.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "servicebusexporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "servicebusexporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/servicebusexporter/templates/deployment.yaml
+++ b/charts/servicebusexporter/templates/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "servicebusexporter.fullname" . }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "servicebusexporter.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "servicebusexporter.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.addPromAnnotations }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: {{ .Values.service.port | quote }}
+      {{- end }}
+      {{- if and .Values.rewriteAppHTTPProbers .Values.virtualservice.enabled }}
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "servicebusexporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: "CONNECTION_STRING"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "servicebusexporter.fullname" . }}
+                  key: "connectionString"
+          {{- if .Values.service.port }}
+            - name: "PORT"
+              value: {{ .Values.service.port | quote }}
+          {{- end }}
+          {{- if .Values.timeout }}
+            - name: "TIMEOUT"
+              value: {{ .Values.timeout | quote }}
+          {{- end }}
+          {{- if .Values.verbose }}
+            - name: "VERBOSE"
+              value: {{ .Values.verbose | quote }}
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/servicebusexporter/templates/ingress.yaml
+++ b/charts/servicebusexporter/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "servicebusexporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/servicebusexporter/templates/secret.yaml
+++ b/charts/servicebusexporter/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "servicebusexporter.fullname" . }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+data:
+  connectionString: {{ .Values.connectionString | b64enc }}

--- a/charts/servicebusexporter/templates/service.yaml
+++ b/charts/servicebusexporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "servicebusexporter.fullname" . }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "servicebusexporter.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/servicebusexporter/templates/serviceaccount.yaml
+++ b/charts/servicebusexporter/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "servicebusexporter.serviceAccountName" . }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/servicebusexporter/templates/tests/test-connection.yaml
+++ b/charts/servicebusexporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "servicebusexporter.fullname" . }}-test-connection"
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "servicebusexporter.fullname" . }}:{{ .Values.service.port }}/metrics']
+  restartPolicy: Never

--- a/charts/servicebusexporter/templates/virtualservice.yaml
+++ b/charts/servicebusexporter/templates/virtualservice.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.virtualservice.enabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{ include "servicebusexporter.fullname" . }}
+  labels:
+{{ include "servicebusexporter.labels" . | indent 4 }}
+spec:
+  hosts:
+  {{- if $host := .Values.virtualservice.hosts }}
+  {{- range $host := .Values.virtualservice.hosts }}
+  - {{ $host | quote }}
+  {{- end }}
+  {{- else }}
+  - {{ include "servicebusexporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ include "servicebusexporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster
+  - {{ include "servicebusexporter.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "servicebusexporter.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "servicebusexporter.fullname" . }}
+  {{- end }}
+  {{- if $gateway := .Values.virtualservice.gateways }}
+  gateways:
+  {{- range $gateway := .Values.virtualservice.gateways }}
+  - {{ $gateway | quote }}
+  {{- end }}
+  {{- end }}
+  http:
+  - match:
+{{- toYaml .Values.virtualservice.matches | nindent 4 -}}
+    route:
+    - destination:
+        port:
+          number: {{ .Values.service.port }}
+        host: {{ include "servicebusexporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end }}

--- a/charts/servicebusexporter/values.yaml
+++ b/charts/servicebusexporter/values.yaml
@@ -1,0 +1,82 @@
+# Default values for servicebusexporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+connectionString: ''
+timeout: 30s
+verbose: false
+addPromAnnotations: true
+rewriteAppHTTPProbers: false
+
+replicaCount: 1
+
+image:
+  repository: marcinbudny/servicebus_exporter
+  tag: 0.1.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9580
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: ""
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+virtualservice:
+  enabled: false
+  gateways: []
+  hosts: []
+  matches:
+    - uri:
+        prefix: /metrics
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/create-index.sh
+++ b/create-index.sh
@@ -1,0 +1,8 @@
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+pushd $DIR/charts
+helm package servicebusexporter --destination=.deploy
+cr upload -o giggio -r servicebus_exporter -p .deploy
+popd
+pushd $DIR
+cr index -i index.yaml -p ./charts/.deploy/ -o giggio -r servicebus_exporter -c https://github.com/giggio/servicebus_exporter/
+popd


### PR DESCRIPTION
This is a first iteration to try to create a Helm chart for the service bus exporter. We can discuss it and I'll make the changes you need.

This is self hosted on Github pages, I reached out to the Kubeapps people and they did not reply. See the index file at: https://giggio.github.io/servicebus_exporter/index.yaml

A release was created to make it work: https://github.com/giggio/servicebus_exporter/releases/tag/servicebusexporter-0.0.1

I used the chart releaser from the Helm project to create the index and the release on Github: https://github.com/helm/chart-releaser

Please let me know what you think and we can move it from there.